### PR TITLE
two more cvmfs Spack areas

### DIFF
--- a/sbin/sync-cvmfs-fermilab
+++ b/sbin/sync-cvmfs-fermilab
@@ -20,7 +20,7 @@ exec 3>&2 >>$LOG 2>&1
 #   and if it doesn't, sync both top level and in products
 #
 # if it is "packages/" use "update_spack" tools to update it
-PROJECTS="products/common products/artdaq ebd genie noble packages/common"
+PROJECTS="products/common products/artdaq ebd genie noble packages/common packages/external packages/larsoft"
 REPO=fermilab.opensciencegrid.org
 
 TRIGGERED=""
@@ -95,7 +95,7 @@ for PROJECT in $PROJECTS; do
         PATH=$SPACK_TOOLS/bin:$PATH
         WORKFILE=$TOP/triggers/$BASEP/workfile
         update_spack $WORKFILE /cvmfs/$REPO/$PROJECT/spack/current/NULL
-        update_ups_to_spack  /cvmfs/$REPO/$PROJECT/spack/current/NULL
+        update_ups_to_spack  /cvmfs/$REPO/$PROJECT/spack/current/NULL || true
     ;;
 
     *)


### PR DESCRIPTION
Tweak to sbin/sync-cvmfs-fermilab to allow an externals and larsoft spack areas under fermilab.opensciencegrid.org/packages 